### PR TITLE
Add External Links to App Store and Google Play Badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,13 +294,14 @@
           </div>
           <div class="flex-item flex-column">
             <div class="control-group">
-              <a href="javascript:void(0)" target="_blank" class="custom-image-button">
+              <a href="https://apps.apple.com/" target="_blank" class="custom-image-button">
                 <img src="img/app-store-badge.png" width="150">
               </a>
-              <a href="javascript:void(0)" target="_blank" class="custom-image-button">
+              <a href="https://play.google.com/" target="_blank" class="custom-image-button">
                 <img src="img/google-play-badge.png" width="150">
               </a>
             </div>
+            
           </div>
         </div>
         <div class="flex-row">


### PR DESCRIPTION
### PR Description:
This PR updates the HTML for the App Store and Google Play badges to include external links that direct users to the respective app stores. The changes ensure that clicking the badges will open the App Store and Google Play pages in a new tab.

### Changes made:

- Updated th**e href attributes** of the **App Store and Google Play** links to point to their official URLs.
- Ensured that the links open in a new tab by setting **target="_blank"**.

This update improves the user experience by providing direct access to the app stores via the badges.